### PR TITLE
Update com.fasterxml.jackson.core:jackson-core to 2.9.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     ext.joda_version = '2.9.9'
     ext.avro_version = '1.8.2'
     ext.httpclient_version = '4.5.6'
-    ext.jackson_version = '2.9.5'
+    ext.jackson_version = '2.9.8'
     ext.kafka_version = '0.11.0.2'
     repositories {
         maven {


### PR DESCRIPTION
Updates com.fasterxml.jackson.core:jackson-core to 2.9.8.

If you'd like to skip this version, you can just close this PR, and I won't make another for the same version.

And if commits from elsewhere cause a conflict I'll automatically resolve them unless you make changes yourself.

Cheerio.