### PR TITLE
Update org.glassfish.tyrus:tyrus-container-grizzly-client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     compile "org.apache.avro:avro:$avro_version"
     compile 'org.glassfish.tyrus:tyrus-client:1.13.1'
     compile 'org.glassfish.tyrus:tyrus-core:1.13.1'
-    compile 'org.glassfish.tyrus:tyrus-container-grizzly-client:1.13.1'
+    compile 'org.glassfish.tyrus:tyrus-container-grizzly-client:1.15'
 
     testCompile "org.apache.logging.log4j:log4j-slf4j-impl:$log4j_version"
     testCompile "io.kotlintest:kotlintest-runner-junit5:$kotlin_test"


### PR DESCRIPTION
Updates org.glassfish.tyrus:tyrus-container-grizzly-client to 1.15.

If you'd like to skip this version, you can just close this PR, and I won't make another for the same version.

And if commits from elsewhere cause a conflict I'll automatically resolve them unless you make changes yourself.

Cheerio.