### PR TITLE
Update org.apache.logging.log4j:log4j-slf4j-impl to 2.11.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.2.60'
     ext.kotlin_test = '3.1.5'
-    ext.log4j_version = '2.9.1'
+    ext.log4j_version = '2.11.1'
     ext.slf4j_version = '1.7.25'
     ext.joda_version = '2.9.9'
     ext.avro_version = '1.8.2'


### PR DESCRIPTION
Updates org.apache.logging.log4j:log4j-slf4j-impl to 2.11.1.

If you'd like to skip this version, you can just close this PR, and I won't make another for the same version.

And if commits from elsewhere cause a conflict I'll automatically resolve them unless you make changes yourself.

Cheerio.