### PR TITLE
Update io.kotlintest:kotlintest-runner-junit5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlin_version = '1.2.60'
-    ext.kotlin_test = '3.1.5'
+    ext.kotlin_test = '3.2.0'
     ext.log4j_version = '2.9.1'
     ext.slf4j_version = '1.7.25'
     ext.joda_version = '2.9.9'


### PR DESCRIPTION
Updates io.kotlintest:kotlintest-runner-junit5 to 3.2.0.

If you'd like to skip this version, you can just close this PR, and I won't make another for the same version.

And if commits from elsewhere cause a conflict I'll automatically resolve them unless you make changes yourself.

Cheerio.