### PR TITLE
Update org.apache.kafka:kafka-clients to 2.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 buildscript {
-    ext.kotlin_version = '1.2.60'
+    ext.kotlin_version = '1.3.11'
     ext.kotlin_test = '3.1.5'
-    ext.log4j_version = '2.9.1'
+    ext.log4j_version = '2.11.1'
     ext.slf4j_version = '1.7.25'
-    ext.joda_version = '2.9.9'
+    ext.joda_version = '2.10.1'
     ext.avro_version = '1.8.2'
     ext.httpclient_version = '4.5.6'
-    ext.jackson_version = '2.9.5'
-    ext.kafka_version = '0.11.0.2'
+    ext.jackson_version = '2.9.8'
+    ext.kafka_version = '2.1.0'
     repositories {
         maven {
             url "https://plugins.gradle.org/m2/"
@@ -57,7 +57,7 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"
     compile "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version"
     compile "org.apache.avro:avro:$avro_version"
-    compile 'org.glassfish.tyrus:tyrus-client:1.13.1'
+    compile 'org.glassfish.tyrus:tyrus-client:1.15'
     compile 'org.glassfish.tyrus:tyrus-core:1.13.1'
     compile 'org.glassfish.tyrus:tyrus-container-grizzly-client:1.13.1'
 


### PR DESCRIPTION
Updates org.apache.kafka:kafka-clients to 2.1.0.

If you'd like to skip this version, you can just close this PR, and I won't make another for the same version.

And if commits from elsewhere cause a conflict I'll automatically resolve them unless you make changes yourself.

Cheerio.