### PR TITLE
Update org.jetbrains.kotlin:kotlin-stdlib to 1.3.20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.11'
+    ext.kotlin_version = '1.3.20'
     ext.kotlin_test = '3.1.5'
     ext.log4j_version = '2.11.1'
     ext.slf4j_version = '1.7.25'


### PR DESCRIPTION
Updates org.jetbrains.kotlin:kotlin-stdlib to 1.3.20.

If you'd like to skip this version, you can just close this PR, and I won't make another for the same version.

And if commits from elsewhere cause a conflict I'll automatically resolve them unless you make changes yourself.

Cheerio.