### PR TITLE
Update org.apache.httpcomponents:httpclient to 4.5.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.slf4j_version = '1.7.25'
     ext.joda_version = '2.10.1'
     ext.avro_version = '1.8.2'
-    ext.httpclient_version = '4.5.6'
+    ext.httpclient_version = '4.5.7'
     ext.jackson_version = '2.9.8'
     ext.kafka_version = '0.11.0.2'
     repositories {


### PR DESCRIPTION
Updates org.apache.httpcomponents:httpclient to 4.5.7.

If you'd like to skip this version, you can just close this PR, and I won't make another for the same version.

And if commits from elsewhere cause a conflict I'll automatically resolve them unless you make changes yourself.

Cheerio.