### PR TITLE
Update org.apache.kafka:kafka-clients to 2.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.avro_version = '1.8.2'
     ext.httpclient_version = '4.5.6'
     ext.jackson_version = '2.9.8'
-    ext.kafka_version = '0.11.0.2'
+    ext.kafka_version = '2.1.0'
     repositories {
         maven {
             url "https://plugins.gradle.org/m2/"


### PR DESCRIPTION
Updates org.apache.kafka:kafka-clients to 2.1.0.

If you'd like to skip this version, you can just close this PR, and I won't make another for the same version.

And if commits from elsewhere cause a conflict I'll automatically resolve them unless you make changes yourself.

Cheerio.