### PR TITLE
Update org.apache.logging.log4j:log4j-slf4j-impl to 2.11.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 buildscript {
-    ext.kotlin_version = '1.3.11'
+    ext.kotlin_version = '1.3.20'
     ext.kotlin_test = '3.1.5'
-    ext.log4j_version = '2.11.1'
+    ext.log4j_version = '2.11.2'
     ext.slf4j_version = '1.7.25'
     ext.joda_version = '2.10.1'
     ext.avro_version = '1.8.2'
-    ext.httpclient_version = '4.5.6'
+    ext.httpclient_version = '4.5.7'
     ext.jackson_version = '2.9.8'
     ext.kafka_version = '0.11.0.2'
     repositories {
@@ -59,7 +59,7 @@ dependencies {
     compile "org.apache.avro:avro:$avro_version"
     compile 'org.glassfish.tyrus:tyrus-client:1.15'
     compile 'org.glassfish.tyrus:tyrus-core:1.13.1'
-    compile 'org.glassfish.tyrus:tyrus-container-grizzly-client:1.13.1'
+    compile 'org.glassfish.tyrus:tyrus-container-grizzly-client:1.15'
 
     testCompile "org.apache.logging.log4j:log4j-slf4j-impl:$log4j_version"
     testCompile "io.kotlintest:kotlintest-runner-junit5:$kotlin_test"


### PR DESCRIPTION
Updates org.apache.logging.log4j:log4j-slf4j-impl to 2.11.2.

If you'd like to skip this version, you can just close this PR, and I won't make another for the same version.

And if commits from elsewhere cause a conflict I'll automatically resolve them unless you make changes yourself.

Cheerio.